### PR TITLE
This Extends the Plugin to Include System Messages in Clan Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The Bingo Team Indicators plugin adds an icon to people's name in the chatbox, s
 -> Fill in the in-game names of the participants in the textfields, separated by commas.  
 -> The plugin will now add an icon before the names of the participants based on which team they're in Clan chat, Guest Clan chat, and Friends chat!
 
-*Please note: This plugin WILL remove Ironman icons in these chats too.*
-
 See screenshots: *(screenshots use outdated icons)*
 
 ![chatbox](https://github.com/EwwItsMike/CustomDiscordPresence/assets/120571801/38ae9596-5a10-4368-9368-ce5f7e133656)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bingo Team Indicators
-Do you struggle remembering who is on your Bingo team durin Clan Events?
-Have you accidentally cheered for an opposing team getting a drop, thinking it was your team?
+Do you struggle remembering who is on your Bingo team during Clan Events?
+Have you accidentally cheered for an opposing team member getting a drop, thinking they're on your team?
 
 No more!
 
@@ -11,7 +11,7 @@ The Bingo Team Indicators plugin adds an icon to people's name in the chatbox, s
 # How it works
 -> Simply fill in the desired amount of teams (between 1 and 15) in the Sidepanel.  
 -> Fill in the in-game names of the participants in the textfields, separated by commas.  
--> The plugin will now add an icon before the names of the participants based on which team they're in in Clan chat, Guest Clan chat, and Friends chat!
+-> The plugin will now add an icon before the names of the participants based on which team they're in Clan chat, Guest Clan chat, and Friends chat!
 
 *Please note: This plugin WILL remove Ironman icons in these chats too.*
 

--- a/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
+++ b/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
@@ -154,7 +154,7 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 			if (msgType == ChatMessageType.CLAN_CHAT || msgType == ChatMessageType.CLAN_GUEST_CHAT || msgType == ChatMessageType.FRIENDSCHAT || msgType == ChatMessageType.CLAN_GIM_CHAT)
 			{
 				String cleanRsn = Text.standardize(Text.removeTags(msg.getName()));
-				if (cleanRsn.equals(rsnFromEvent))
+				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
 				{
 					msg.setName(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase())) + rsn);
 					needsRefresh = true;

--- a/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
+++ b/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
@@ -105,9 +105,9 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 		}
 		else if (event.getType() == ChatMessageType.CLAN_MESSAGE || event.getType() == ChatMessageType.CLAN_GUEST_MESSAGE || event.getType() == ChatMessageType.CLAN_GIM_MESSAGE) {
 			String name = Text.standardize(Text.removeTags(event.getMessage().toLowerCase()));
-			name = name.split(" has a funny ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
+			name = name.split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
 			if (nameNumberCombo.containsKey(name)) {
-				rebuildChat(Text.removeTags(event.getMessage()).split(" has a funny ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0]);
+				rebuildChat(Text.removeTags(event.getMessage()).split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0]);
 			}
 		}
 	}
@@ -162,8 +162,8 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 			}
 			else if (msgType == ChatMessageType.CLAN_MESSAGE || msgType == ChatMessageType.CLAN_GUEST_MESSAGE || msgType == ChatMessageType.CLAN_GIM_MESSAGE)
 			{
-				String cleanRsn = Text.standardize(Text.removeTags(msg.getValue())).toLowerCase().split(" has a funny ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
-				if (cleanRsn.equals(rsnFromEvent))
+				String cleanRsn = Text.standardize(Text.removeTags(msg.getValue())).toLowerCase().split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
+				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
 				{
 					msg.setValue(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase())) + msg.getValue());
 					needsRefresh = true;

--- a/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
+++ b/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
@@ -154,7 +154,7 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 			if (msgType == ChatMessageType.CLAN_CHAT || msgType == ChatMessageType.CLAN_GUEST_CHAT || msgType == ChatMessageType.FRIENDSCHAT)
 			{
 				String cleanRsn = Text.standardize(Text.removeTags(msg.getName()));
-				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
+				if (cleanRsn.equals(rsnFromEvent) && !msg.getName().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
 				{
 					msg.setName(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase())) + rsn);
 					needsRefresh = true;
@@ -163,7 +163,7 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 			else if (msgType == ChatMessageType.CLAN_MESSAGE || msgType == ChatMessageType.CLAN_GUEST_MESSAGE)
 			{
 				String cleanRsn = Text.standardize(Text.removeTags(msg.getValue())).toLowerCase().split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
-				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
+				if (cleanRsn.equals(rsnFromEvent) && !msg.getName().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
 				{
 					msg.setValue(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase())) + msg.getValue());
 					needsRefresh = true;

--- a/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
+++ b/src/main/java/com/bingoteamindicators/BingoTeamIndicatorsPlugin.java
@@ -96,14 +96,14 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 
 	@Subscribe
 	public void onChatMessage(ChatMessage event) {
-		if (event.getType() == ChatMessageType.CLAN_CHAT || event.getType() == ChatMessageType.CLAN_GUEST_CHAT || event.getType() == ChatMessageType.FRIENDSCHAT || event.getType() == ChatMessageType.CLAN_GIM_CHAT) {
+		if (event.getType() == ChatMessageType.CLAN_CHAT || event.getType() == ChatMessageType.CLAN_GUEST_CHAT || event.getType() == ChatMessageType.FRIENDSCHAT) {
 			String name = Text.standardize(Text.removeTags(event.getName().toLowerCase()));
 			if (nameNumberCombo.containsKey(name)) {
 				//rebuildChat(Text.removeTags(event.getName()));
 				rebuildChat(event.getName());
 			}
 		}
-		else if (event.getType() == ChatMessageType.CLAN_MESSAGE || event.getType() == ChatMessageType.CLAN_GUEST_MESSAGE || event.getType() == ChatMessageType.CLAN_GIM_MESSAGE) {
+		else if (event.getType() == ChatMessageType.CLAN_MESSAGE || event.getType() == ChatMessageType.CLAN_GUEST_MESSAGE) {
 			String name = Text.standardize(Text.removeTags(event.getMessage().toLowerCase()));
 			name = name.split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
 			if (nameNumberCombo.containsKey(name)) {
@@ -151,7 +151,7 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 		for (MessageNode msg : msgs) {
 			ChatMessageType msgType = msg.getType();
 			String rsnFromEvent = Text.standardize(Text.removeTags(rsn)).toLowerCase();
-			if (msgType == ChatMessageType.CLAN_CHAT || msgType == ChatMessageType.CLAN_GUEST_CHAT || msgType == ChatMessageType.FRIENDSCHAT || msgType == ChatMessageType.CLAN_GIM_CHAT)
+			if (msgType == ChatMessageType.CLAN_CHAT || msgType == ChatMessageType.CLAN_GUEST_CHAT || msgType == ChatMessageType.FRIENDSCHAT)
 			{
 				String cleanRsn = Text.standardize(Text.removeTags(msg.getName()));
 				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))
@@ -160,7 +160,7 @@ public class BingoTeamIndicatorsPlugin extends Plugin {
 					needsRefresh = true;
 				}
 			}
-			else if (msgType == ChatMessageType.CLAN_MESSAGE || msgType == ChatMessageType.CLAN_GUEST_MESSAGE || msgType == ChatMessageType.CLAN_GIM_MESSAGE)
+			else if (msgType == ChatMessageType.CLAN_MESSAGE || msgType == ChatMessageType.CLAN_GUEST_MESSAGE)
 			{
 				String cleanRsn = Text.standardize(Text.removeTags(msg.getValue())).toLowerCase().split(" has a funny ")[0].split(" has achieved ")[0].split(" has been defeated ")[0].split(" has completed ")[0].split(" has defeated ")[0].split(" has died and ")[0].split(" has reached ")[0].split(" received a ")[0].split(" received special ")[0];
 				if (cleanRsn.equals(rsnFromEvent) && !msg.getValue().startsWith(iconTags.get(nameNumberCombo.get(cleanRsn.toLowerCase()))))


### PR DESCRIPTION
1. Support added for:

CLAN_MESSAGE: A system message in a clan chat.
CLAN_GUEST_MESSAGE: A system message in the guest clan chat.
For these messages, Name field is not used in the message, so I had to identify name as the text that comes before the strings below. Since these strings start with a space and are 12+ character long, this should always work regardless of player names.

has a funny
has achieved
has achieved
has been defeated
has completed
has defeated
has died and
has reached
received a
received special
Note that " has completed " does not work because CA's messages contain CA_ID in the message value. I don't think it's worthwhile to include this unless bingos are being run that include CAs. Would need to add regex to remove text like this from the message value "CA_ID:396|".

2. Ironman icons are no longer removed anymore, and there's logic to ensure all icons never duplicate and never go missing.

3. Originally I had the idea to include GIM Chat as part of this scope, but I don't think it's worth including. If this is later wanted, note CLAN_GIM_CHAT & CLAN_GIM_MESSAGE do not behave as expected and will need a special handler. GIM groups are 5 players maximum, so I really don't think it's worth the system processing time nor dev time to get it working.

4. Finally, my updates build on top of the architecture of the original version for human reability. The original design includes the ability to update Team Membership then the plugin would reupdate previous chat messages retroactively to reflect the new membership, but I have not considered this with my updates. This functionality may be gone, but this improves performance by not reprocessing messages that have already been processed.